### PR TITLE
Update Downloader.cs

### DIFF
--- a/Securcube.ImapDownloader/Data/Downloader.cs
+++ b/Securcube.ImapDownloader/Data/Downloader.cs
@@ -348,7 +348,7 @@ namespace Securcube.ImapDownloader.Data
                                    totalMessagesDownloaded++;
                                    folder.DownloadedItems++;
 
-                                   messageIdSafeName = System.Text.RegularExpressions.Regex.Replace(msg.Headers["Message-ID"] + "", "[<>\\/:]", "");
+                                   messageIdSafeName = System.Text.RegularExpressions.Regex.Replace(msg.Headers["Message-ID"] + "", "[|\"<>\\/:]", "");
 
                                    string msgPrefix = item.UniqueId + "";
 


### PR DESCRIPTION
Expand Message-ID Regex to include pipes and double quotes. This was to address a bug where message IDs had a pipe char in, Downloader then failed when trying to create a file with a pipe in the name. I think the ideal approach would be similar to the "illegalChars" one or one based around encoding URL-style, but I couldn't get that to work quickly and this solved the immediate problem. Not sure if the double quote is of practical value but included for completeness.